### PR TITLE
Remove a javascript error with the Node.contains()

### DIFF
--- a/modal.js
+++ b/modal.js
@@ -116,7 +116,7 @@
 	modal.setFocus = function (hash) {
 		if (modal.activeElement &&
 				typeof modal.activeElement.contains === 'function' &&
-				!modal.activeElement.contains(hash)) {
+				!modal.activeElement.contains(document.getElementById(hash))) {
 
 			// Set element with last focus
 			modal.lastActive = document.activeElement;


### PR DESCRIPTION
Hi!

I had a JavaScript error, when I was testing the video demo.
The Node.contains() was used with a string in arguments instead of an element.

Mainly, I have no idea why you are doing this test.
modal.focus() is called just one time, and we know that modal.activeElement is the hashElement.

Cheers,
Thomas.
