### PR TITLE
BugFix: Remove a javascript error when a hash has no HTML element associate

### DIFF
--- a/modal.js
+++ b/modal.js
@@ -64,13 +64,14 @@
 	// When showing overlay, prevent background from scrolling
 	window.onhashchange = function () {
 		var hash = window.location.hash.replace('#', '');
+		var modalElement = document.getElementById(hash);
 		var modalChild;
 
-		// If hash is set
-		if (hash !== '' && hash !== '!') {
+		// If the hash element exists
+		if (modalElement) {
 
 			// Get first element in selected element
-			modalChild = document.getElementById(hash).children[0];
+			modalChild = modalElement.children[0];
 
 			// When we deal with a modal and class `has-overlay` is not set on html yet
 			if (modalChild && modalChild.className.match(/modal-inner/) && !document.documentElement.className.match(/has-overlay/)) {
@@ -79,8 +80,8 @@
 				document.documentElement.className += ' has-overlay';
 
 				// Mark modal as active
-				document.getElementById(hash).className += ' is-active';
-				modal.activeElement = document.getElementById(hash);
+				modalElement.className += ' is-active';
+				modal.activeElement = modalElement;
 
 				// Set the focus to the modal
 				modal.setFocus(hash);


### PR DESCRIPTION
Hi!

It is not a critical bug, but there was a javascript error when we call a hash which correspond to any HTML element.

See you,
Thomas.
