### PR TITLE
Fire an events if page loaded with hash string

### DIFF
--- a/download/modal.js
+++ b/download/modal.js
@@ -63,7 +63,7 @@
 
 
 	// When showing overlay, prevent background from scrolling
-	window.onhashchange = function () {
+	modal.mainHandler = function () {
 		var hash = window.location.hash.replace('#', '');
 		var modalElement = document.getElementById(hash);
 		var htmlClasses = document.documentElement.className;
@@ -113,6 +113,8 @@
 		}
 	};
 
+    window.addEventListener('hashchange', modal.mainHandler, false);
+    window.addEventListener('load', modal.mainHandler, false);
 
 	/*
 	 * Accessibility

--- a/modal.js
+++ b/modal.js
@@ -63,7 +63,7 @@
 
 
 	// When showing overlay, prevent background from scrolling
-	window.onhashchange = function () {
+	modal.mainHandler = function () {
 		var hash = window.location.hash.replace('#', '');
 		var modalElement = document.getElementById(hash);
 		var htmlClasses = document.documentElement.className;
@@ -113,6 +113,8 @@
 		}
 	};
 
+    window.addEventListener('hashchange', modal.mainHandler, false);
+    window.addEventListener('load', modal.mainHandler, false);
 
 	/*
 	 * Accessibility


### PR DESCRIPTION
Problem: if page loaded with hash '#modal', we can see modal window, but 'cssmodal:show' event not triggered. As a consequence, we have problem with display content in modal window.
