### PR TITLE
Close string as HTML-attribute

### DIFF
--- a/download/modal.css
+++ b/download/modal.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /**
  * Modal as reusable module
  *

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
         &lt;footer&gt;&lt;!-- Footer --&gt;&lt;/footer&gt;
     &lt;/div&gt;
 
-    &lt;a href="#!" class="modal-close" title="Close this modal"
+    &lt;a href="#!" class="modal-close" title="Close this modal" data-close="Close"
         data-dismiss="modal"&gt;&times;&lt;/a&gt;
 &lt;/section&gt;</code></pre>
 
@@ -243,7 +243,7 @@
 
 				<!-- Use Hash-Bang to maintain scroll position when closing modal -->
 				<a href="#!" class="modal-close" title="Close this modal"
-						data-dismiss="modal">&times;</a>
+						data-dismiss="modal" data-close="Close">&times;</a>
 			</section>
 
 
@@ -267,7 +267,7 @@
 
 				<!-- Use Hash-Bang to maintain scroll position when closing modal -->
 				<a href="#!" class="modal-close"
-						title="Close this modal">&times;</a>
+						title="Close this modal" data-close="Close">&times;</a>
 			</section>
 
 
@@ -298,7 +298,7 @@
 
 				<!-- Use Hash-Bang to maintain scroll position when closing modal -->
 				<a href="#!" class="modal-close"
-						title="Close this modal">&times;</a>
+						title="Close this modal" data-close="Close">&times;</a>
 			</section>
 
 

--- a/modal.scss
+++ b/modal.scss
@@ -276,7 +276,7 @@ html {
 			}
 
 			&:after {
-				content: 'Close';
+				content: attr(data-close);
 				top: 0.4em;
 				left: 1em;
 				z-index: 40;

--- a/site/css/main.css
+++ b/site/css/main.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*
  * Modals build with pure CSS
  * by @drublic - http://drublic.de/
@@ -986,7 +987,7 @@ html {
     display: none;
   }
   .semantic-content .modal-close:after {
-    content: 'Close';
+    content: attr(data-close);
     top: 0.4em;
     left: 1em;
     z-index: 40;

--- a/tests/index.html
+++ b/tests/index.html
@@ -35,7 +35,7 @@
 
 			<!-- Use Hash-Bang to maintain scroll position when closing modal -->
 			<a href="#!" class="modal-close" title="Close this modal"
-					data-dismiss="modal">&times;</a>
+					data-dismiss="modal" data-close="Close">&times;</a>
 		</section>
 
 		<!-- Source -->

--- a/tests/modal.css
+++ b/tests/modal.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 /*
  * Tests for CSS Modal
  * by @drublic - http://drublic.de/
@@ -224,7 +225,7 @@ html {
     display: none;
   }
   .semantic-content .modal-close:after, ._modal .modal-close:after {
-    content: 'Close';
+    content: attr(data-close);
     top: 0.4em;
     left: 1em;
     z-index: 40;


### PR DESCRIPTION
This moves the close-string from CSS content to HTML as data-attribute as issued in #39.
