### PR TITLE
Register for AMD and prevent global variables when unnecessary

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,8 @@
 	"smarttabs": true,
 
 	"globals": {
-		"jQuery": true
+		"jQuery": true,
+		"define": true,
+		"module": true
 	}
 }

--- a/modal.js
+++ b/modal.js
@@ -149,7 +149,15 @@
 		}
 	};
 
-	// Export CSSModal into global space
-	global.CSSModal = modal;
+	if (typeof module === 'object' && module && typeof module.exports === 'object') {
+		// Expose modal for loaders that implement the Node module pattern.
+		module.exports = modal;
+	} else if (typeof define === 'function' && define.amd) {
+		// Register as an AMD module
+		define([], function () { return modal; });
+	} else if (typeof global === 'object' && typeof global.document === 'object') {
+		// Export CSSModal into global space
+		global.CSSModal = modal;
+	}
 
 }(window));


### PR DESCRIPTION
Avoid global variable when using css-modal with an AMD loader. 
