### PR TITLE
Added note on IE 8 compatibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,6 +162,7 @@
 					<div class="tab-content">
 						<p>As stated above you don't need JavaScript to get a good experience out of CSS Modals. But there are some issues where JavaScript helps:</p>
 						<ul>
+              <li>IE 8 compatibility.</li>
 							<li>Pressing escape: If you press <code>ESC</code> on your keyboard while the modal is visible it closes itself. This behavior cannot be done with CSS only.</li>
 							<li>Preventing background page from scrolling: If you scroll within the modal and you reach the end you don't want the page in the background to scroll. To prevent this JavaScript pushs a CSS class selector to the body element.</li>
 							<li>Being accessible: To get the browser's focus to the modal and back after closing.</li>


### PR DESCRIPTION
I realized that the javascript was needed for the modal to be displayed in IE 8 (it sets the is-active class to avoid IE 8's lack of support for the target selector). As a result, I've added a note to this effect.
