### PR TITLE
IE8: Hashchange event is not working with Bean

### DIFF
--- a/_modal-core.scss
+++ b/_modal-core.scss
@@ -68,6 +68,8 @@ html {
 
 	&.is-active {
 		display: block\9;
+		height: 100%\9;
+		width: 100%\9;
 	}
 
 

--- a/build/modal.css
+++ b/build/modal.css
@@ -63,6 +63,8 @@ html {
 }
 .is-active.modal--show {
   display: block\9;
+  height: 100% \9;
+  width: 100% \9;
 }
 .modal--show:target, .is-active.modal--show {
   display: block\9;

--- a/modal.js
+++ b/modal.js
@@ -49,10 +49,17 @@
 				return;
 			}
 
-			if (global.bean) {
-				bean.on(element, event, callback);
-			} else {
+			// Default way to support events
+			if ('addEventListener' in element) {
 				element.addEventListener(event, callback, false);
+
+			// If the event is a hashchange
+			} else if (event === 'hashchange' && element.attachEvent) {
+				element.attachEvent('on' + event, callback);
+
+			// If the event is not a haschange and bean is supported
+			} else {
+				bean.on(element, event, callback);
 			}
 		},
 

--- a/plugins/gallery.scss
+++ b/plugins/gallery.scss
@@ -73,10 +73,11 @@ $gallery--min-size: 98px;
 		> li {
 			float: left;
 			padding: 0.2em;
+		}
 
-			img {
-				display: block;
-			}
+		img {
+			display: block;
+			border: 0;
 		}
 	}
 }

--- a/test/modal.css
+++ b/test/modal.css
@@ -70,6 +70,8 @@ html {
 }
 .is-active.modal--gallery, .is-active.modal--fade, .is-active.modal--plainscreen, .is-active.modal--zoomin, .is-active.modal--zoomout, .is-active.modal--slidefromtop, .is-active.modal--bouncefromtop, .is-active.modal--bouncefromtopshaky, .is-active.modal--show, .is-active._modal {
   display: block\9;
+  height: 100% \9;
+  width: 100% \9;
 }
 .modal--gallery:target, .modal--fade:target, .modal--plainscreen:target, .modal--zoomin:target, .modal--zoomout:target, .modal--slidefromtop:target, .modal--bouncefromtop:target, .modal--bouncefromtopshaky:target, .modal--show:target, ._modal:target, .is-active.modal--gallery, .is-active.modal--fade, .is-active.modal--plainscreen, .is-active.modal--zoomin, .is-active.modal--zoomout, .is-active.modal--slidefromtop, .is-active.modal--bouncefromtop, .is-active.modal--bouncefromtopshaky, .is-active.modal--show, .is-active._modal {
   display: block\9;
@@ -855,8 +857,9 @@ html {
   float: left;
   padding: 0.2em;
 }
-.modal--gallery .modal-content-list > li img {
+.modal--gallery .modal-content-list img {
   display: block;
+  border: 0;
 }
 
 .modal--gallery-navigation {


### PR DESCRIPTION
Bean does not seem to support hashchange for IE8 properly. This
commit fixes this behavior by utilizing attachEvent for IE8.
