### PR TITLE
Better keep focus : avoid non visible focusable elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## HEAD
+* Better keep focus : avoid non visible focusable elements
 * Remove unused height declaration from core
 
 ## 1.1.8 - 20.06.2014

--- a/modal.js
+++ b/modal.js
@@ -164,8 +164,8 @@
 				return;
 			}
 
-			var firstTabbableElement = modal.getFirstElementVisible(allTabbableElements),
-				lastTabbableElement = modal.getLastElementVisible(allTabbableElements);
+			var firstTabbableElement = modal.getFirstElementVisible(allTabbableElements);
+			var lastTabbableElement = modal.getLastElementVisible(allTabbableElements);
 
 			var focusHandler = function (event) {
 				var keyCode = event.which || event.keyCode;
@@ -199,13 +199,15 @@
 		 * Return the first visible element of a nodeList
 		 *
 		 * @param nodeList The nodelist to parse
-		 * @return {*}
+		 * @return {Node|null} Returns a specific node or null if no element found
 		 */
 		getFirstElementVisible: function (nodeList) {
 			var nodeListLength = nodeList.length;
+
 			// If the first item is not visible
 			if (!modal.isElementVisible(nodeList[0])) {
 				for (var i = 1; i < nodeListLength - 1; i++) {
+
 					// Iterate elements in the NodeList, return the first visible
 					if (modal.isElementVisible(nodeList[i])) {
 						return nodeList[i];
@@ -222,14 +224,16 @@
 		 * Return the last visible element of a nodeList
 		 *
 		 * @param nodeList The nodelist to parse
-		 * @return {*}
+		 * @return {Node|null} Returns a specific node or null if no element found
 		 */
 		getLastElementVisible: function (nodeList) {
-			var nodeListLength = nodeList.length,
-				lastTabbableElement = nodeList[nodeListLength - 1];
+			var nodeListLength = nodeList.length;
+			var lastTabbableElement = nodeList[nodeListLength - 1];
+
 			// If the last item is not visible
 			if (!modal.isElementVisible(lastTabbableElement)) {
 				for (var i = nodeListLength - 1; i >= 0; i--) {
+
 					// Iterate elements in the NodeList, return the first visible
 					if (modal.isElementVisible(nodeList[i])) {
 						return nodeList[i];


### PR DESCRIPTION
This commit handles the visibility of elements in the keepFocus functionality, if an element of the list is not visible it tries to get the next focusable candidate.

I met this situation on a project with some hidden div at the top of the modal and the keepFocus was focusing hidden focusable element, which was not the "correct" behavior.
