### PR TITLE
Remove non-core effects of the modal (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## HEAD
+* Update core effects and only use necessary prefixes
+* Remove non-core effects of the modal (#161)
 
 ## 1.2.0 - 16.10.2014
 * Use * for files to ignore and include in bower.json

--- a/_modal-animations.scss
+++ b/_modal-animations.scss
@@ -1,99 +1,76 @@
 /**
  * All animations for CSS Modal
+ *
+ * Available:
+ * - %modal--transition-fade (fade)
+ * - %modal--transition-zoomIn (zooms in)
+ * - %modal--transition-plainScreen (hides background)
+ *
+ * Usage:
+ *
+ * .selector {
+ * 		@extend %modal--transition-fade;
+ * }
+ *
  */
 
-// Keyframes for scale down of stacked modal on small screens
-@-webkit-keyframes scaleDown {
-	to { opacity: 0; -webkit-transform: scale(.8); }
-}
-@-moz-keyframes scaleDown {
-	to { opacity: 0; -moz-transform: scale(.8); }
-}
-@keyframes scaleDown {
-	to { opacity: 0; transform: scale(.8); }
-}
-
+// Configuration:
+$transition-duration: 0.4s;
+$transition-size-start: scale(0);
+$transition-size-end: scale(1);
 
 // Fade in the modal
 %modal--transition-fade {
 	@media screen and (min-width: $modal-small-breakpoint) {
-		-webkit-transition: opacity 0.4s;
-		     -o-transition: opacity 0.4s;
-		        transition: opacity 0.4s;
+		transition: opacity $transition-duration;
 	}
 
 	@extend %modal;
 	@extend %modal-theme;
 }
 
-
-// Fade in and zoomIn the modal
+// Fade in and zoom in the modal
 %modal--transition-zoomIn {
 	@extend %modal;
 	@extend %modal-theme;
 
-	// Scale to 0
+	// Scale to zero
 	.modal-inner {
-		-webkit-transform: scale(0);
-		   -moz-transform: scale(0);
-		     -o-transform: scale(0);
-		    -ms-transform: scale(0);
-		        transform: scale(0);
-		        opacity: 0;
-
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
+		-webkit-transform: $transition-size-start;
+		        transform: $transition-size-start;
+		opacity: 0;
+		-webkit-transition: all $transition-duration;
+		        transition: all $transition-duration;
 	}
-
 
 	.modal-close:before {
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-
+		-webkit-transition: all $transition-duration;
+		        transition: all $transition-duration;
 		opacity: 0;
 	}
-
-
 	.modal-close:after {
-		-webkit-transform: scale(0);
-		   -moz-transform: scale(0);
-		     -o-transform: scale(0);
-		    -ms-transform: scale(0);
-		        transform: scale(0);
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-
+		-webkit-transform: $transition-size-start;
+		        transform: $transition-size-start;
+		-webkit-transition: all $transition-duration;
+		        transition: all $transition-duration;
 		opacity: 0;
 	}
-
 
 	// Show modal when requested
 	&:target,
 	&.is-active {
 		.modal-inner {
-			-webkit-transform: scale(1);
-			   -moz-transform: scale(1);
-			     -o-transform: scale(1);
-			    -ms-transform: scale(1);
-			        transform: scale(1);
+			-webkit-transform: $transition-size-end;
+			        transform: $transition-size-end;
 			opacity: 1;
 		}
-
 
 		.modal-close:before {
 			opacity: 1;
 		}
-
-
 		.modal-close:after {
-			-webkit-transform: scale(1);
-			   -moz-transform: scale(1);
-			     -o-transform: scale(1);
-			    -ms-transform: scale(1);
-			        transform: scale(1);
+			-webkit-transform: $transition-size-end;
+			        transform: $transition-size-end;
 			opacity: 1;
 			// Move back to proper position
 			top: 25px;
@@ -107,456 +84,38 @@
 	}
 }
 
-
-// Fade in, zoomIn and hide backgrund in the modal
+// Fade in, zoom in and hide backgrund in the modal
 %modal--transition-plainScreen {
 	@extend %modal;
 	@extend %modal-theme;
 	@extend %modal-theme-plainScreen;
 	@extend %modal--transition-zoomIn;
 
-
 	.modal-inner {
-		-webkit-box-shadow: 0 0 15px -5px rgba(0, 0, 0, 0.25);
-		        box-shadow: 0 0 15px -5px rgba(0, 0, 0, 0.25);
+		box-shadow: 0 0 15px -5px rgba(0, 0, 0, 0.25);
 	}
 
-
 	.modal-close:before {
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-
+		-webkit-transition: all $transition-duration;
+		        transition: all $transition-duration;
 		background: $modal-inner-background;
 		opacity: 0;
 	}
-
-
 	.modal-close:after {
-		-webkit-box-shadow: 0 -1px 10px -2px rgba(0, 0, 0, 0.2);
-		        box-shadow: 0 -1px 10px -2px rgba(0, 0, 0, 0.2);
+		box-shadow: 0 -1px 10px -2px rgba(0, 0, 0, 0.2);
 	}
-
 
 	// Show modal when requested
 	&:target,
 	&.is-active {
-
 		.modal-close:before {
 			opacity: 1;
 		}
-
 		.modal-close:after {
 			top: 23px;
 
 			@media screen and (max-width: $modal-small-breakpoint) {
 				top: 5px;
-			}
-		}
-	}
-}
-
-
-// Fade in and downsample the modal
-%modal--transition-zoomOut {
-	@extend %modal;
-	@extend %modal-theme;
-
-	// Scale to 0
-	.modal-inner {
-		-webkit-transform: scale(2);
-		   -moz-transform: scale(2);
-		     -o-transform: scale(2);
-		    -ms-transform: scale(2);
-		        transform: scale(2);
-		        opacity: 0;
-
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-	}
-
-
-	.modal-close:before {
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-
-		opacity: 0;
-	}
-
-
-	.modal-close:after {
-		-webkit-transform: scale(2);
-		   -moz-transform: scale(2);
-		     -o-transform: scale(2);
-		    -ms-transform: scale(2);
-		        transform: scale(2);
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-
-		opacity: 0;
-		// Needs to be moved into the center
-		// of the modal initially
-		top: -125px;
-	}
-
-
-	// Show modal when requested
-	&:target,
-	&.is-active {
-		.modal-inner {
-			-webkit-transform: scale(1);
-			   -moz-transform: scale(1);
-			     -o-transform: scale(1);
-			    -ms-transform: scale(1);
-			        transform: scale(1);
-			opacity: 1;
-		}
-
-
-		.modal-close:before {
-			opacity: 1;
-		}
-
-
-		.modal-close:after {
-			-webkit-transform: scale(1);
-			   -moz-transform: scale(1);
-			     -o-transform: scale(1);
-			    -ms-transform: scale(1);
-			        transform: scale(1);
-			opacity: 1;
-			// Move back to proper position
-			top: 25px;
-
-			@media screen and (max-width: $modal-small-breakpoint) {
-				top: 5px;
-				right: 5px;
-				left: auto;
-			}
-		}
-	}
-}
-
-
-// Slide in from the top
-%modal--transition-slideFromTop {
-	@extend %modal;
-	@extend %modal-theme;
-
-	// Scale to 0
-	.modal-inner {
-		-webkit-transform: translateY(-100%);
-		   -moz-transform: translateY(-100%);
-		     -o-transform: translateY(-100%);
-		    -ms-transform: translateY(-100%);
-		        transform: translateY(-100%);
-
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-	}
-
-
-	.modal-close:before {
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-
-		opacity: 0;
-	}
-
-
-	.modal-close:after {
-		-webkit-transform: translateY(-100%);
-		   -moz-transform: translateY(-100%);
-		     -o-transform: translateY(-100%);
-		    -ms-transform: translateY(-100%);
-		        transform: translateY(-100%);
-
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-
-		opacity: 0;
-		// Needs to be moved into the center
-		// of the modal initially
-		top: -125px;
-	}
-
-
-	// Show modal when requested
-	&:target,
-	&.is-active {
-
-		.modal-inner {
-			-webkit-transform: translateY(0);
-			   -moz-transform: translateY(0);
-			     -o-transform: translateY(0);
-			    -ms-transform: translateY(0);
-			        transform: translateY(0);
-
-			opacity: 1;
-		}
-
-
-		.modal-close:before {
-			opacity: 1;
-		}
-
-
-		.modal-close:after {
-			-webkit-transform: translateY(0);
-			   -moz-transform: translateY(0);
-			     -o-transform: translateY(0);
-			    -ms-transform: translateY(0);
-			        transform: translateY(0);
-
-			opacity: 1;
-			// Move back to proper position
-			top: 25px;
-
-			@media screen and (max-width: $modal-small-breakpoint) {
-				top: 5px;
-				right: 5px;
-				left: auto;
-			}
-		}
-	}
-}
-
-
-// Bounce in animation definition from top
-// shaking the window at the end
-@-webkit-keyframes shaky {
-	0% {
-		-webkit-transform: translateY(-100%);
-	}
-	60% {
-		-webkit-transform: translateX(5%) translateY(5%) rotate(-2deg);
-	}
-	80% {
-		-webkit-transform: translateX(5%) translateY(5%) rotate(2deg);
-	}
-	50%, 70%, 90% {
-		-webkit-transform: translateX(0%) translateY(0%);
-	}
-}
-
-
-// Bounce in animation definition from top
-@-webkit-keyframes bounce {
-	0% {
-		-webkit-transform: translateY(-100%);
-	}
-	60% {
-		-webkit-transform: translateY(5%);
-	}
-	85% {
-		-webkit-transform: translateY(0%);
-	}
-}
-
-
-@-moz-keyframes bounce {
-	0% {
-		-moz-transform: translateY(-100%);
-	}
-	60% {
-		-moz-transform: translateY(5%);
-	}
-	85% {
-		-moz-transform: translateY(0%);
-	}
-}
-
-
-@-o-keyframes bounce {
-	0% {
-		-o-transform: translateY(-100%);
-	}
-	60% {
-		-o-transform: translateY(5%);
-	}
-	85% {
-		-o-transform: translateY(0%);
-	}
-}
-
-
-@-ms-keyframes bounce {
-	0% {
-		-ms-transform: translateY(-100%);
-	}
-	60% {
-		-ms-transform: translateY(5%);
-	}
-	85% {
-		-ms-transform: translateY(0%);
-	}
-}
-
-
-@keyframes bounce {
-	0% {
-		transform: translateY(-100%);
-	}
-	60% {
-		transform: translateY(5%);
-	}
-	85% {
-		transform: translateY(0%);
-	}
-}
-
-
-// Bounce in from top
-%modal--transition-bounceFromTop {
-	@extend %modal;
-	@extend %modal-theme;
-
-	.modal-close:before {
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-
-		opacity: 0;
-	}
-
-
-	.modal-close:after {
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-		-webkit-transition-delay: 0.4s;
-		     -o-transition-delay: 0.4s;
-		        transition-delay: 0.4s;
-		opacity: 0;
-		// Needs to be moved into the center
-		// of the modal initially
-		top: 25px;
-	}
-
-
-	// Show modal when requested
-	&:target,
-	&.is-active {
-
-		.modal-inner {
-			-webkit-animation-name: bounce;
-			   -moz-animation-name: bounce;
-			     -o-animation-name: bounce;
-			    -ms-animation-name: bounce;
-			        animation-name: bounce;
-
-			-webkit-animation-duration: 0.4s;
-			   -moz-animation-duration: 0.4s;
-			     -o-animation-duration: 0.4s;
-			    -ms-animation-duration: 0.4s;
-			        animation-duration: 0.4s;
-
-			-webkit-animation-fill-mode: both;
-			   -moz-animation-fill-mode: both;
-			     -o-animation-fill-mode: both;
-			    -ms-animation-fill-mode: both;
-			        animation-fill-mode: both;
-
-			opacity: 1;
-		}
-
-
-		.modal-close:before {
-			opacity: 1;
-		}
-
-
-		.modal-close:after {
-			opacity: 1;
-			// Move back to proper position
-			top: 25px;
-
-			@media screen and (max-width: $modal-small-breakpoint) {
-				top: 5px;
-				right: 5px;
-				left: auto;
-			}
-		}
-	}
-}
-
-
-// Bounce in from top
-%modal--transition-bounceFromTopShaky {
-	@extend %modal;
-	@extend %modal-theme;
-
-	.modal-close:before {
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-
-		opacity: 0;
-	}
-
-
-	.modal-close:after {
-		-webkit-transition: all 0.4s;
-		     -o-transition: all 0.4s;
-		        transition: all 0.4s;
-		-webkit-transition-delay: 0.6s;
-		     -o-transition-delay: 0.6s;
-		        transition-delay: 0.6s;
-
-		opacity: 0;
-		// Needs to be moved into the center
-		// of the modal initially
-		top: 25px;
-	}
-
-
-	// Show modal when requested
-	&:target,
-	&.is-active {
-
-		.modal-inner {
-			-webkit-animation-name: shaky;
-			   -moz-animation-name: shaky;
-			     -o-animation-name: shaky;
-			    -ms-animation-name: shaky;
-			        animation-name: shaky;
-
-			-webkit-animation-duration: 0.6s;
-			   -moz-animation-duration: 0.6s;
-			     -o-animation-duration: 0.6s;
-			    -ms-animation-duration: 0.6s;
-			        animation-duration: 0.6s;
-
-			-webkit-animation-fill-mode: both;
-			   -moz-animation-fill-mode: both;
-			     -o-animation-fill-mode: both;
-			    -ms-animation-fill-mode: both;
-			        animation-fill-mode: both;
-
-			opacity: 1;
-		}
-
-
-		.modal-close:before {
-			opacity: 1;
-		}
-
-
-		.modal-close:after {
-			opacity: 1;
-			// Move back to proper position
-			top: 25px;
-
-			@media screen and (max-width: $modal-small-breakpoint) {
-				top: 5px;
-				right: 5px;
-				left: auto;
 			}
 		}
 	}

--- a/build/modal.css
+++ b/build/modal.css
@@ -24,7 +24,6 @@ html {
 @media screen and (max-width: 30em) {
   .has-overlay > body {
     overflow: hidden;
-    height: 100%;
   }
 }
 
@@ -254,106 +253,21 @@ html {
   }
 }
 
-@-webkit-keyframes scaleDown {
-  to {
-    opacity: 0;
-    -webkit-transform: scale(0.8);
-  }
-}
-@-moz-keyframes scaleDown {
-  to {
-    opacity: 0;
-    -moz-transform: scale(0.8);
-  }
-}
-@keyframes scaleDown {
-  to {
-    opacity: 0;
-    transform: scale(0.8);
-  }
-}
-@-webkit-keyframes shaky {
-  0% {
-    -webkit-transform: translateY(-100%);
-  }
-
-  60% {
-    -webkit-transform: translateX(5%) translateY(5%) rotate(-2deg);
-  }
-
-  80% {
-    -webkit-transform: translateX(5%) translateY(5%) rotate(2deg);
-  }
-
-  50%, 70%, 90% {
-    -webkit-transform: translateX(0%) translateY(0%);
-  }
-}
-@-webkit-keyframes bounce {
-  0% {
-    -webkit-transform: translateY(-100%);
-  }
-
-  60% {
-    -webkit-transform: translateY(5%);
-  }
-
-  85% {
-    -webkit-transform: translateY(0%);
-  }
-}
-@-moz-keyframes bounce {
-  0% {
-    -moz-transform: translateY(-100%);
-  }
-
-  60% {
-    -moz-transform: translateY(5%);
-  }
-
-  85% {
-    -moz-transform: translateY(0%);
-  }
-}
-@-o-keyframes bounce {
-  0% {
-    -o-transform: translateY(-100%);
-  }
-
-  60% {
-    -o-transform: translateY(5%);
-  }
-
-  85% {
-    -o-transform: translateY(0%);
-  }
-}
-@-ms-keyframes bounce {
-  0% {
-    -ms-transform: translateY(-100%);
-  }
-
-  60% {
-    -ms-transform: translateY(5%);
-  }
-
-  85% {
-    -ms-transform: translateY(0%);
-  }
-}
-@keyframes bounce {
-  0% {
-    transform: translateY(-100%);
-  }
-
-  60% {
-    transform: translateY(5%);
-  }
-
-  85% {
-    transform: translateY(0%);
-  }
-}
+/**
+ * All animations for CSS Modal
+ *
+ * Available:
+ * - %modal--transition-fade (fade)
+ * - %modal--transition-zoomIn (zooms in)
+ * - %modal--transition-plainScreen (hides background)
+ *
+ * Usage:
+ *
+ * .selector {
+ * 		@extend %modal--transition-fade;
+ * }
+ *
+ */
 /**
  * CSS Modal Themes
  * http://drublic.github.com/css-modal
@@ -364,12 +278,12 @@ html {
  * Global Theme Styles
  */
 .modal--show {
-  color: #222222;
+  color: #222;
   line-height: 1.3;
 }
 .modal--show .modal-inner {
   border-radius: 2px;
-  background: white;
+  background: #fff;
   -webkit-box-shadow: 0 0 30px rgba(0, 0, 0, 0.6);
   box-shadow: 0 0 30px rgba(0, 0, 0, 0.6);
   max-width: 100%;
@@ -377,14 +291,14 @@ html {
   transition: max-width 0.25s linear, margin-left 0.125s linear;
 }
 .modal--show header {
-  border-bottom: 1px solid #dddddd;
+  border-bottom: 1px solid #ddd;
   padding: 0 1.2em;
 }
 .modal--show header > h2 {
   margin: 0.5em 0;
 }
 .modal--show .modal-content {
-  border-bottom: 1px solid #dddddd;
+  border-bottom: 1px solid #ddd;
   padding: 15px 1.2em;
 }
 .modal--show footer {
@@ -401,7 +315,7 @@ html {
 }
 .modal--show .modal-close:after {
   content: '\00d7';
-  background: white;
+  background: #fff;
   border-radius: 2px;
   padding: 2px 8px;
   font-size: 1.2em;
@@ -438,3 +352,8 @@ html {
 /*
  * Plain Screen Theme Styles
  */
+/**
+ * Apply the desired modal behavior to your container selector
+ */
+
+/*# sourceMappingURL=modal.css.map */

--- a/index.html
+++ b/index.html
@@ -33,10 +33,6 @@
 			<li><a href="#modal-fade" title="Clicking this link shows the modal">Demo Fade</a></li>
 			<li><a href="#modal-zoomin" title="Clicking this link shows the modal">Demo ZoomIn</a></li>
 			<li><a href="#modal-plainscreen" title="Clicking this link shows the modal">Demo PlainScreen</a></li>
-			<li><a href="#modal-zoomout" title="Clicking this link shows the modal">Demo ZoomOut</a></li>
-			<li><a href="#modal-slidefromtop" title="Clicking this link shows the modal">Demo slideFromTop</a></li>
-			<li><a href="#modal-bouncefromtop" title="Clicking this link shows the modal">Demo bounceFromTop</a></li>
-			<li><a href="#modal-bouncefromtopshaky" title="Clicking this link shows the modal">Demo bounceFromTopShaky</a></li>
 			<li><a href="#modal-html5video" title="Clicking this link shows a modal with HTML5 Video content">Demo HTML5Video</a></li>
 			<li><a href="#modal-image" title="Clicking this link shows a modal with image content">Demo Image</a></li>
 			<li><a href="#modal-image2" title="Clicking this link shows a modal with image content">Demo Image 2</a></li>
@@ -125,59 +121,6 @@
 
 			<div class="modal-inner">
 				<header><h2 id="modal-plainscreen">A plain screen modal</h2></header>
-				<div class="modal-content"><p>Content.</p></div>
-			</div>
-
-			<a href="#!" class="modal-close" title="Close this modal"
-					data-dismiss="modal" data-close="Close">&times;</a>
-		</section>
-
-		<section class="modal--zoomout" id="modal-zoomout"
-				tabindex="-1" role="dialog" aria-labelledby="label-zoomout" aria-hidden="true">
-
-			<div class="modal-inner">
-				<header>
-					<h2 id="label-zoomout">A zoomed out modal</h2>
-				</header>
-
-				<div class="modal-content">
-					<p>Content.</p>
-				</div>
-			</div>
-
-			<a href="#!" class="modal-close" title="Close this modal"
-					data-dismiss="modal" data-close="Close">&times;</a>
-		</section>
-
-		<section class="modal--slidefromtop" id="modal-slidefromtop"
-				tabindex="-1" role="dialog" aria-labelledby="label-slidefromtop" aria-hidden="true">
-
-			<div class="modal-inner">
-				<header><h2 id="label-slidefromtop">A modal that slides from the top</h2></header>
-				<div class="modal-content"><p>Content.</p></div>
-			</div>
-
-			<a href="#!" class="modal-close" title="Close this modal"
-					data-dismiss="modal" data-close="Close">&times;</a>
-		</section>
-
-		<section class="modal--bouncefromtop" id="modal-bouncefromtop"
-				tabindex="-1" role="dialog" aria-labelledby="label-bouncefromtop" aria-hidden="true">
-
-			<div class="modal-inner">
-				<header><h2 id="label-bouncefromtop">A modal that bounces from the top</h2></header>
-				<div class="modal-content"><p>Content.</p></div>
-			</div>
-
-			<a href="#!" class="modal-close" title="Close this modal"
-					data-dismiss="modal" data-close="Close">&times;</a>
-		</section>
-
-		<section class="modal--bouncefromtopshaky" id="modal-bouncefromtopshaky"
-				tabindex="-1" role="dialog" aria-labelledby="label-bouncefromtopshaky" aria-hidden="true">
-
-			<div class="modal-inner">
-				<header><h2 id="label-bouncefromtopshaky">A modal that bounces shakey from the top</h2></header>
 				<div class="modal-content"><p>Content.</p></div>
 			</div>
 

--- a/test/modal.css
+++ b/test/modal.css
@@ -31,11 +31,10 @@ html {
 @media screen and (max-width: 30em) {
   .has-overlay > body {
     overflow: hidden;
-    height: 100%;
   }
 }
 
-.modal--gallery, .modal--fade, .modal--plainscreen, .modal--zoomin, .modal--zoomout, .modal--slidefromtop, .modal--bouncefromtop, .modal--bouncefromtopshaky, .modal--show, ._modal {
+.modal--gallery, .modal--fade, .modal--plainscreen, .modal--zoomin, .modal--show, ._modal {
   -webkit-transform: translate(0, 100%);
   -moz-transform: translate(0, 100%);
   -o-transform: translate(0, 100%);
@@ -55,7 +54,7 @@ html {
   opacity: 0;
   display: none\9;
 }
-.modal--gallery:target, .modal--fade:target, .modal--plainscreen:target, .modal--zoomin:target, .modal--zoomout:target, .modal--slidefromtop:target, .modal--bouncefromtop:target, .modal--bouncefromtopshaky:target, .modal--show:target, ._modal:target, .is-active.modal--gallery, .is-active.modal--fade, .is-active.modal--plainscreen, .is-active.modal--zoomin, .is-active.modal--zoomout, .is-active.modal--slidefromtop, .is-active.modal--bouncefromtop, .is-active.modal--bouncefromtopshaky, .is-active.modal--show, .is-active._modal {
+.modal--gallery:target, .modal--fade:target, .modal--plainscreen:target, .modal--zoomin:target, .modal--show:target, ._modal:target, .is-active.modal--gallery, .is-active.modal--fade, .is-active.modal--plainscreen, .is-active.modal--zoomin, .is-active.modal--show, .is-active._modal {
   -webkit-transform: translate(0, 0);
   -moz-transform: translate(0, 0);
   -o-transform: translate(0, 0);
@@ -65,15 +64,15 @@ html {
   height: auto;
   opacity: 1;
 }
-.is-active.modal--gallery, .is-active.modal--fade, .is-active.modal--plainscreen, .is-active.modal--zoomin, .is-active.modal--zoomout, .is-active.modal--slidefromtop, .is-active.modal--bouncefromtop, .is-active.modal--bouncefromtopshaky, .is-active.modal--show, .is-active._modal {
+.is-active.modal--gallery, .is-active.modal--fade, .is-active.modal--plainscreen, .is-active.modal--zoomin, .is-active.modal--show, .is-active._modal {
   display: block\9;
   height: 100% \9;
   width: 100% \9;
 }
-.modal--gallery:target, .modal--fade:target, .modal--plainscreen:target, .modal--zoomin:target, .modal--zoomout:target, .modal--slidefromtop:target, .modal--bouncefromtop:target, .modal--bouncefromtopshaky:target, .modal--show:target, ._modal:target, .is-active.modal--gallery, .is-active.modal--fade, .is-active.modal--plainscreen, .is-active.modal--zoomin, .is-active.modal--zoomout, .is-active.modal--slidefromtop, .is-active.modal--bouncefromtop, .is-active.modal--bouncefromtopshaky, .is-active.modal--show, .is-active._modal {
+.modal--gallery:target, .modal--fade:target, .modal--plainscreen:target, .modal--zoomin:target, .modal--show:target, ._modal:target, .is-active.modal--gallery, .is-active.modal--fade, .is-active.modal--plainscreen, .is-active.modal--zoomin, .is-active.modal--show, .is-active._modal {
   display: block\9;
 }
-.modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--zoomout .modal-inner, .modal--slidefromtop .modal-inner, .modal--bouncefromtop .modal-inner, .modal--bouncefromtopshaky .modal-inner, .modal--show .modal-inner, ._modal .modal-inner {
+.modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--show .modal-inner, ._modal .modal-inner {
   position: absolute;
   top: 50px;
   left: 50%;
@@ -84,40 +83,32 @@ html {
   -webkit-overflow-scrolling: touch;
 }
 @media \0screen\,screen\9 {
-  .modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--zoomout .modal-inner, .modal--slidefromtop .modal-inner, .modal--bouncefromtop .modal-inner, .modal--bouncefromtopshaky .modal-inner, .modal--show .modal-inner, ._modal .modal-inner {
+  .modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--show .modal-inner, ._modal .modal-inner {
     background: transparent;
   }
 }
-.modal--gallery .modal-inner > img, .modal--fade .modal-inner > img, .modal--plainscreen .modal-inner > img, .modal--zoomin .modal-inner > img, .modal--zoomout .modal-inner > img, .modal--slidefromtop .modal-inner > img, .modal--bouncefromtop .modal-inner > img, .modal--bouncefromtopshaky .modal-inner > img, .modal--show .modal-inner > img, ._modal .modal-inner > img,
+.modal--gallery .modal-inner > img, .modal--fade .modal-inner > img, .modal--plainscreen .modal-inner > img, .modal--zoomin .modal-inner > img, .modal--show .modal-inner > img, ._modal .modal-inner > img,
 .modal--gallery .modal-inner > video,
 .modal--fade .modal-inner > video,
 .modal--plainscreen .modal-inner > video,
 .modal--zoomin .modal-inner > video,
-.modal--zoomout .modal-inner > video,
-.modal--slidefromtop .modal-inner > video,
-.modal--bouncefromtop .modal-inner > video,
-.modal--bouncefromtopshaky .modal-inner > video,
 .modal--show .modal-inner > video,
 ._modal .modal-inner > video,
 .modal--gallery .modal-inner > iframe,
 .modal--fade .modal-inner > iframe,
 .modal--plainscreen .modal-inner > iframe,
 .modal--zoomin .modal-inner > iframe,
-.modal--zoomout .modal-inner > iframe,
-.modal--slidefromtop .modal-inner > iframe,
-.modal--bouncefromtop .modal-inner > iframe,
-.modal--bouncefromtopshaky .modal-inner > iframe,
 .modal--show .modal-inner > iframe,
 ._modal .modal-inner > iframe {
   width: 100%;
   height: auto;
   min-height: 300px;
 }
-.modal--gallery .modal-inner > img, .modal--fade .modal-inner > img, .modal--plainscreen .modal-inner > img, .modal--zoomin .modal-inner > img, .modal--zoomout .modal-inner > img, .modal--slidefromtop .modal-inner > img, .modal--bouncefromtop .modal-inner > img, .modal--bouncefromtopshaky .modal-inner > img, .modal--show .modal-inner > img, ._modal .modal-inner > img {
+.modal--gallery .modal-inner > img, .modal--fade .modal-inner > img, .modal--plainscreen .modal-inner > img, .modal--zoomin .modal-inner > img, .modal--show .modal-inner > img, ._modal .modal-inner > img {
   width: auto;
   max-width: 100%;
 }
-.modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--zoomout .modal-content, .modal--slidefromtop .modal-content, .modal--bouncefromtop .modal-content, .modal--bouncefromtopshaky .modal-content, .modal--show .modal-content, ._modal .modal-content {
+.modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--show .modal-content, ._modal .modal-content {
   position: relative;
   max-height: 400px;
   max-height: 80vh;
@@ -126,31 +117,31 @@ html {
   -webkit-overflow-scrolling: touch;
 }
 @media \0screen\,screen\9 {
-  .modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--zoomout .modal-content, .modal--slidefromtop .modal-content, .modal--bouncefromtop .modal-content, .modal--bouncefromtopshaky .modal-content, .modal--show .modal-content, ._modal .modal-content {
+  .modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--show .modal-content, ._modal .modal-content {
     overflow: visible;
   }
 }
-.modal--gallery .modal-content > *, .modal--fade .modal-content > *, .modal--plainscreen .modal-content > *, .modal--zoomin .modal-content > *, .modal--zoomout .modal-content > *, .modal--slidefromtop .modal-content > *, .modal--bouncefromtop .modal-content > *, .modal--bouncefromtopshaky .modal-content > *, .modal--show .modal-content > *, ._modal .modal-content > * {
+.modal--gallery .modal-content > *, .modal--fade .modal-content > *, .modal--plainscreen .modal-content > *, .modal--zoomin .modal-content > *, .modal--show .modal-content > *, ._modal .modal-content > * {
   max-width: 100%;
 }
-.modal--gallery footer, .modal--fade footer, .modal--plainscreen footer, .modal--zoomin footer, .modal--zoomout footer, .modal--slidefromtop footer, .modal--bouncefromtop footer, .modal--bouncefromtopshaky footer, .modal--show footer, ._modal footer {
+.modal--gallery footer, .modal--fade footer, .modal--plainscreen footer, .modal--zoomin footer, .modal--show footer, ._modal footer {
   border-top: 1px solid white;
   padding: 0 1.2em 18px;
   background: #f0f0f0;
   border-radius: 2px;
 }
-.modal--gallery .modal-close, .modal--fade .modal-close, .modal--plainscreen .modal-close, .modal--zoomin .modal-close, .modal--zoomout .modal-close, .modal--slidefromtop .modal-close, .modal--bouncefromtop .modal-close, .modal--bouncefromtopshaky .modal-close, .modal--show .modal-close, ._modal .modal-close {
+.modal--gallery .modal-close, .modal--fade .modal-close, .modal--plainscreen .modal-close, .modal--zoomin .modal-close, .modal--show .modal-close, ._modal .modal-close {
   display: block;
   height: 1px;
   clip: rect(0 0 0 0);
   margin: -1px;
   overflow: hidden;
 }
-.modal--gallery .modal-close:focus:after, .modal--fade .modal-close:focus:after, .modal--plainscreen .modal-close:focus:after, .modal--zoomin .modal-close:focus:after, .modal--zoomout .modal-close:focus:after, .modal--slidefromtop .modal-close:focus:after, .modal--bouncefromtop .modal-close:focus:after, .modal--bouncefromtopshaky .modal-close:focus:after, .modal--show .modal-close:focus:after, ._modal .modal-close:focus:after {
+.modal--gallery .modal-close:focus:after, .modal--fade .modal-close:focus:after, .modal--plainscreen .modal-close:focus:after, .modal--zoomin .modal-close:focus:after, .modal--show .modal-close:focus:after, ._modal .modal-close:focus:after {
   outline: 1px dotted;
   outline: -webkit-focus-ring-color auto 5px;
 }
-.modal--gallery .modal-close:before, .modal--fade .modal-close:before, .modal--plainscreen .modal-close:before, .modal--zoomin .modal-close:before, .modal--zoomout .modal-close:before, .modal--slidefromtop .modal-close:before, .modal--bouncefromtop .modal-close:before, .modal--bouncefromtopshaky .modal-close:before, .modal--show .modal-close:before, ._modal .modal-close:before {
+.modal--gallery .modal-close:before, .modal--fade .modal-close:before, .modal--plainscreen .modal-close:before, .modal--zoomin .modal-close:before, .modal--show .modal-close:before, ._modal .modal-close:before {
   content: '';
   position: absolute;
   top: 0;
@@ -159,7 +150,7 @@ html {
   bottom: 0;
   z-index: 10;
 }
-.modal--gallery .modal-close:after, .modal--fade .modal-close:after, .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after, .modal--zoomout .modal-close:after, .modal--slidefromtop .modal-close:after, .modal--bouncefromtop .modal-close:after, .modal--bouncefromtopshaky .modal-close:after, .modal--show .modal-close:after, ._modal .modal-close:after {
+.modal--gallery .modal-close:after, .modal--fade .modal-close:after, .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after, .modal--show .modal-close:after, ._modal .modal-close:after {
   content: '\00d7';
   position: absolute;
   top: 25px;
@@ -168,19 +159,19 @@ html {
   margin-right: -325px;
 }
 @media screen and (max-width: 690px) {
-  .modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--zoomout .modal-inner, .modal--slidefromtop .modal-inner, .modal--bouncefromtop .modal-inner, .modal--bouncefromtopshaky .modal-inner, .modal--show .modal-inner, ._modal .modal-inner {
+  .modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--show .modal-inner, ._modal .modal-inner {
     width: auto;
     left: 20px;
     right: 20px;
     margin-left: 0;
   }
-  .modal--gallery .modal-close:after, .modal--fade .modal-close:after, .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after, .modal--zoomout .modal-close:after, .modal--slidefromtop .modal-close:after, .modal--bouncefromtop .modal-close:after, .modal--bouncefromtopshaky .modal-close:after, .modal--show .modal-close:after, ._modal .modal-close:after {
+  .modal--gallery .modal-close:after, .modal--fade .modal-close:after, .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after, .modal--show .modal-close:after, ._modal .modal-close:after {
     margin-right: 0 !important;
     right: 20px;
   }
 }
 @media screen and (max-width: 30em) {
-  .modal--gallery, .modal--fade, .modal--plainscreen, .modal--zoomin, .modal--zoomout, .modal--slidefromtop, .modal--bouncefromtop, .modal--bouncefromtopshaky, .modal--show, ._modal {
+  .modal--gallery, .modal--fade, .modal--plainscreen, .modal--zoomin, .modal--show, ._modal {
     -webkit-transform: translate(0, 400px);
     -webkit-transform: translate3d(0, 100%, 0);
     transform: translate3d(0, 100%, 0);
@@ -192,10 +183,10 @@ html {
     display: block;
     bottom: auto;
   }
-  .modal--gallery:target, .modal--fade:target, .modal--plainscreen:target, .modal--zoomin:target, .modal--zoomout:target, .modal--slidefromtop:target, .modal--bouncefromtop:target, .modal--bouncefromtopshaky:target, .modal--show:target, ._modal:target, .is-active.modal--gallery, .is-active.modal--fade, .is-active.modal--plainscreen, .is-active.modal--zoomin, .is-active.modal--zoomout, .is-active.modal--slidefromtop, .is-active.modal--bouncefromtop, .is-active.modal--bouncefromtopshaky, .is-active.modal--show, .is-active._modal {
+  .modal--gallery:target, .modal--fade:target, .modal--plainscreen:target, .modal--zoomin:target, .modal--show:target, ._modal:target, .is-active.modal--gallery, .is-active.modal--fade, .is-active.modal--plainscreen, .is-active.modal--zoomin, .is-active.modal--show, .is-active._modal {
     height: 100%;
   }
-  .modal--gallery:before, .modal--fade:before, .modal--plainscreen:before, .modal--zoomin:before, .modal--zoomout:before, .modal--slidefromtop:before, .modal--bouncefromtop:before, .modal--bouncefromtopshaky:before, .modal--show:before, ._modal:before {
+  .modal--gallery:before, .modal--fade:before, .modal--plainscreen:before, .modal--zoomin:before, .modal--show:before, ._modal:before {
     content: '';
     position: fixed;
     top: 0;
@@ -203,7 +194,7 @@ html {
     right: 0;
     z-index: 30;
   }
-  .modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--zoomout .modal-inner, .modal--slidefromtop .modal-inner, .modal--bouncefromtop .modal-inner, .modal--bouncefromtopshaky .modal-inner, .modal--show .modal-inner, ._modal .modal-inner {
+  .modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--show .modal-inner, ._modal .modal-inner {
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;
@@ -213,7 +204,7 @@ html {
     height: 100%;
     overflow: auto;
   }
-  .modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--zoomout .modal-content, .modal--slidefromtop .modal-content, .modal--bouncefromtop .modal-content, .modal--bouncefromtopshaky .modal-content, .modal--show .modal-content, ._modal .modal-content {
+  .modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--show .modal-content, ._modal .modal-content {
     max-height: none;
     -ms-word-break: break-all;
     word-break: break-word;
@@ -221,13 +212,13 @@ html {
     -moz-hyphens: auto;
     hyphens: auto;
   }
-  .modal--gallery .modal-close, .modal--fade .modal-close, .modal--plainscreen .modal-close, .modal--zoomin .modal-close, .modal--zoomout .modal-close, .modal--slidefromtop .modal-close, .modal--bouncefromtop .modal-close, .modal--bouncefromtopshaky .modal-close, .modal--show .modal-close, ._modal .modal-close {
+  .modal--gallery .modal-close, .modal--fade .modal-close, .modal--plainscreen .modal-close, .modal--zoomin .modal-close, .modal--show .modal-close, ._modal .modal-close {
     right: auto;
   }
-  .modal--gallery .modal-close:before, .modal--fade .modal-close:before, .modal--plainscreen .modal-close:before, .modal--zoomin .modal-close:before, .modal--zoomout .modal-close:before, .modal--slidefromtop .modal-close:before, .modal--bouncefromtop .modal-close:before, .modal--bouncefromtopshaky .modal-close:before, .modal--show .modal-close:before, ._modal .modal-close:before {
+  .modal--gallery .modal-close:before, .modal--fade .modal-close:before, .modal--plainscreen .modal-close:before, .modal--zoomin .modal-close:before, .modal--show .modal-close:before, ._modal .modal-close:before {
     display: none;
   }
-  .modal--gallery .modal-close:after, .modal--fade .modal-close:after, .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after, .modal--zoomout .modal-close:after, .modal--slidefromtop .modal-close:after, .modal--bouncefromtop .modal-close:after, .modal--bouncefromtopshaky .modal-close:after, .modal--show .modal-close:after, ._modal .modal-close:after {
+  .modal--gallery .modal-close:after, .modal--fade .modal-close:after, .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after, .modal--show .modal-close:after, ._modal .modal-close:after {
     top: 5px !important;
     right: 5px;
     left: auto;
@@ -236,18 +227,18 @@ html {
   }
 }
 @media screen and (max-height: 46em) and (min-width: 30em) {
-  .modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--zoomout .modal-content, .modal--slidefromtop .modal-content, .modal--bouncefromtop .modal-content, .modal--bouncefromtopshaky .modal-content, .modal--show .modal-content, ._modal .modal-content {
+  .modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--show .modal-content, ._modal .modal-content {
     max-height: 340px;
     max-height: 50vh;
   }
 }
 @media screen and (max-height: 36em) and (min-width: 30em) {
-  .modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--zoomout .modal-content, .modal--slidefromtop .modal-content, .modal--bouncefromtop .modal-content, .modal--bouncefromtopshaky .modal-content, .modal--show .modal-content, ._modal .modal-content {
+  .modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--show .modal-content, ._modal .modal-content {
     max-height: 265px;
     max-height: 40vh;
   }
 }
-.is-stacked.modal--gallery, .is-stacked.modal--fade, .is-stacked.modal--plainscreen, .is-stacked.modal--zoomin, .is-stacked.modal--zoomout, .is-stacked.modal--slidefromtop, .is-stacked.modal--bouncefromtop, .is-stacked.modal--bouncefromtopshaky, .is-stacked.modal--show, .is-stacked._modal {
+.is-stacked.modal--gallery, .is-stacked.modal--fade, .is-stacked.modal--plainscreen, .is-stacked.modal--zoomin, .is-stacked.modal--show, .is-stacked._modal {
   -webkit-transform: translate(0, 0) scale(1, 1);
   -moz-transform: translate(0, 0) scale(1, 1);
   -o-transform: translate(0, 0) scale(1, 1);
@@ -255,89 +246,72 @@ html {
   transform: translate(0, 0) scale(1, 1);
   opacity: 1;
 }
-.is-stacked.modal--gallery .modal-inner, .is-stacked.modal--fade .modal-inner, .is-stacked.modal--plainscreen .modal-inner, .is-stacked.modal--zoomin .modal-inner, .is-stacked.modal--zoomout .modal-inner, .is-stacked.modal--slidefromtop .modal-inner, .is-stacked.modal--bouncefromtop .modal-inner, .is-stacked.modal--bouncefromtopshaky .modal-inner, .is-stacked.modal--show .modal-inner, .is-stacked._modal .modal-inner {
+.is-stacked.modal--gallery .modal-inner, .is-stacked.modal--fade .modal-inner, .is-stacked.modal--plainscreen .modal-inner, .is-stacked.modal--zoomin .modal-inner, .is-stacked.modal--show .modal-inner, .is-stacked._modal .modal-inner {
   -webkit-animation: scaleDown .7s ease both;
   -moz-animation: scaleDown .7s ease both;
   animation: scaleDown .7s ease both;
 }
-.is-stacked.modal--gallery .modal-close, .is-stacked.modal--fade .modal-close, .is-stacked.modal--plainscreen .modal-close, .is-stacked.modal--zoomin .modal-close, .is-stacked.modal--zoomout .modal-close, .is-stacked.modal--slidefromtop .modal-close, .is-stacked.modal--bouncefromtop .modal-close, .is-stacked.modal--bouncefromtopshaky .modal-close, .is-stacked.modal--show .modal-close, .is-stacked._modal .modal-close {
+.is-stacked.modal--gallery .modal-close, .is-stacked.modal--fade .modal-close, .is-stacked.modal--plainscreen .modal-close, .is-stacked.modal--zoomin .modal-close, .is-stacked.modal--show .modal-close, .is-stacked._modal .modal-close {
   opacity: 0;
 }
 @media screen and (max-width: 30em) {
-  .is-stacked.modal--gallery, .is-stacked.modal--fade, .is-stacked.modal--plainscreen, .is-stacked.modal--zoomin, .is-stacked.modal--zoomout, .is-stacked.modal--slidefromtop, .is-stacked.modal--bouncefromtop, .is-stacked.modal--bouncefromtopshaky, .is-stacked.modal--show, .is-stacked._modal {
+  .is-stacked.modal--gallery, .is-stacked.modal--fade, .is-stacked.modal--plainscreen, .is-stacked.modal--zoomin, .is-stacked.modal--show, .is-stacked._modal {
     -webkit-animation: scaleDown .7s ease both;
     -moz-animation: scaleDown .7s ease both;
     animation: scaleDown .7s ease both;
   }
-  .is-stacked.modal--gallery .modal-inner, .is-stacked.modal--fade .modal-inner, .is-stacked.modal--plainscreen .modal-inner, .is-stacked.modal--zoomin .modal-inner, .is-stacked.modal--zoomout .modal-inner, .is-stacked.modal--slidefromtop .modal-inner, .is-stacked.modal--bouncefromtop .modal-inner, .is-stacked.modal--bouncefromtopshaky .modal-inner, .is-stacked.modal--show .modal-inner, .is-stacked._modal .modal-inner {
+  .is-stacked.modal--gallery .modal-inner, .is-stacked.modal--fade .modal-inner, .is-stacked.modal--plainscreen .modal-inner, .is-stacked.modal--zoomin .modal-inner, .is-stacked.modal--show .modal-inner, .is-stacked._modal .modal-inner {
     -webkit-animation: none;
     -moz-animation: none;
     animation: none;
   }
-  .is-stacked.modal--gallery .modal-close, .is-stacked.modal--fade .modal-close, .is-stacked.modal--plainscreen .modal-close, .is-stacked.modal--zoomin .modal-close, .is-stacked.modal--zoomout .modal-close, .is-stacked.modal--slidefromtop .modal-close, .is-stacked.modal--bouncefromtop .modal-close, .is-stacked.modal--bouncefromtopshaky .modal-close, .is-stacked.modal--show .modal-close, .is-stacked._modal .modal-close {
+  .is-stacked.modal--gallery .modal-close, .is-stacked.modal--fade .modal-close, .is-stacked.modal--plainscreen .modal-close, .is-stacked.modal--zoomin .modal-close, .is-stacked.modal--show .modal-close, .is-stacked._modal .modal-close {
     opacity: 1;
   }
 }
 
-@-webkit-keyframes scaleDown {
-  to {
-    opacity: 0;
-    -webkit-transform: scale(0.8);
-  }
-}
-@-moz-keyframes scaleDown {
-  to {
-    opacity: 0;
-    -moz-transform: scale(0.8);
-  }
-}
-@keyframes scaleDown {
-  to {
-    opacity: 0;
-    transform: scale(0.8);
-  }
-}
+/**
+ * All animations for CSS Modal
+ *
+ * Available:
+ * - %modal--transition-fade (fade)
+ * - %modal--transition-zoomIn (zooms in)
+ * - %modal--transition-plainScreen (hides background)
+ *
+ * Usage:
+ *
+ * .selector {
+ * 		@extend %modal--transition-fade;
+ * }
+ *
+ */
 @media screen and (min-width: 30em) {
   .modal--gallery, .modal--fade {
-    -webkit-transition: opacity 0.4s;
-    -o-transition: opacity 0.4s;
     transition: opacity 0.4s;
   }
 }
 
 .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner {
   -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -o-transform: scale(0);
-  -ms-transform: scale(0);
   transform: scale(0);
   opacity: 0;
   -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
   transition: all 0.4s;
 }
 .modal--plainscreen .modal-close:before, .modal--zoomin .modal-close:before {
   -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
   transition: all 0.4s;
   opacity: 0;
 }
 .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after {
   -webkit-transform: scale(0);
-  -moz-transform: scale(0);
-  -o-transform: scale(0);
-  -ms-transform: scale(0);
   transform: scale(0);
   -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
   transition: all 0.4s;
   opacity: 0;
 }
 .modal--plainscreen:target .modal-inner, .modal--zoomin:target .modal-inner, .is-active.modal--plainscreen .modal-inner, .is-active.modal--zoomin .modal-inner {
   -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -o-transform: scale(1);
-  -ms-transform: scale(1);
   transform: scale(1);
   opacity: 1;
 }
@@ -346,9 +320,6 @@ html {
 }
 .modal--plainscreen:target .modal-close:after, .modal--zoomin:target .modal-close:after, .is-active.modal--plainscreen .modal-close:after, .is-active.modal--zoomin .modal-close:after {
   -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -o-transform: scale(1);
-  -ms-transform: scale(1);
   transform: scale(1);
   opacity: 1;
   top: 25px;
@@ -362,18 +333,15 @@ html {
 }
 
 .modal--plainscreen .modal-inner {
-  -webkit-box-shadow: 0 0 15px -5px rgba(0, 0, 0, 0.25);
   box-shadow: 0 0 15px -5px rgba(0, 0, 0, 0.25);
 }
 .modal--plainscreen .modal-close:before {
   -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
   transition: all 0.4s;
-  background: white;
+  background: #fff;
   opacity: 0;
 }
 .modal--plainscreen .modal-close:after {
-  -webkit-box-shadow: 0 -1px 10px -2px rgba(0, 0, 0, 0.2);
   box-shadow: 0 -1px 10px -2px rgba(0, 0, 0, 0.2);
 }
 .modal--plainscreen:target .modal-close:before, .is-active.modal--plainscreen .modal-close:before {
@@ -388,299 +356,6 @@ html {
   }
 }
 
-.modal--zoomout .modal-inner {
-  -webkit-transform: scale(2);
-  -moz-transform: scale(2);
-  -o-transform: scale(2);
-  -ms-transform: scale(2);
-  transform: scale(2);
-  opacity: 0;
-  -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
-  transition: all 0.4s;
-}
-.modal--zoomout .modal-close:before {
-  -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
-  transition: all 0.4s;
-  opacity: 0;
-}
-.modal--zoomout .modal-close:after {
-  -webkit-transform: scale(2);
-  -moz-transform: scale(2);
-  -o-transform: scale(2);
-  -ms-transform: scale(2);
-  transform: scale(2);
-  -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
-  transition: all 0.4s;
-  opacity: 0;
-  top: -125px;
-}
-.modal--zoomout:target .modal-inner, .is-active.modal--zoomout .modal-inner {
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -o-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-  opacity: 1;
-}
-.modal--zoomout:target .modal-close:before, .is-active.modal--zoomout .modal-close:before {
-  opacity: 1;
-}
-.modal--zoomout:target .modal-close:after, .is-active.modal--zoomout .modal-close:after {
-  -webkit-transform: scale(1);
-  -moz-transform: scale(1);
-  -o-transform: scale(1);
-  -ms-transform: scale(1);
-  transform: scale(1);
-  opacity: 1;
-  top: 25px;
-}
-@media screen and (max-width: 30em) {
-  .modal--zoomout:target .modal-close:after, .is-active.modal--zoomout .modal-close:after {
-    top: 5px;
-    right: 5px;
-    left: auto;
-  }
-}
-
-.modal--slidefromtop .modal-inner {
-  -webkit-transform: translateY(-100%);
-  -moz-transform: translateY(-100%);
-  -o-transform: translateY(-100%);
-  -ms-transform: translateY(-100%);
-  transform: translateY(-100%);
-  -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
-  transition: all 0.4s;
-}
-.modal--slidefromtop .modal-close:before {
-  -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
-  transition: all 0.4s;
-  opacity: 0;
-}
-.modal--slidefromtop .modal-close:after {
-  -webkit-transform: translateY(-100%);
-  -moz-transform: translateY(-100%);
-  -o-transform: translateY(-100%);
-  -ms-transform: translateY(-100%);
-  transform: translateY(-100%);
-  -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
-  transition: all 0.4s;
-  opacity: 0;
-  top: -125px;
-}
-.modal--slidefromtop:target .modal-inner, .is-active.modal--slidefromtop .modal-inner {
-  -webkit-transform: translateY(0);
-  -moz-transform: translateY(0);
-  -o-transform: translateY(0);
-  -ms-transform: translateY(0);
-  transform: translateY(0);
-  opacity: 1;
-}
-.modal--slidefromtop:target .modal-close:before, .is-active.modal--slidefromtop .modal-close:before {
-  opacity: 1;
-}
-.modal--slidefromtop:target .modal-close:after, .is-active.modal--slidefromtop .modal-close:after {
-  -webkit-transform: translateY(0);
-  -moz-transform: translateY(0);
-  -o-transform: translateY(0);
-  -ms-transform: translateY(0);
-  transform: translateY(0);
-  opacity: 1;
-  top: 25px;
-}
-@media screen and (max-width: 30em) {
-  .modal--slidefromtop:target .modal-close:after, .is-active.modal--slidefromtop .modal-close:after {
-    top: 5px;
-    right: 5px;
-    left: auto;
-  }
-}
-
-@-webkit-keyframes shaky {
-  0% {
-    -webkit-transform: translateY(-100%);
-  }
-
-  60% {
-    -webkit-transform: translateX(5%) translateY(5%) rotate(-2deg);
-  }
-
-  80% {
-    -webkit-transform: translateX(5%) translateY(5%) rotate(2deg);
-  }
-
-  50%, 70%, 90% {
-    -webkit-transform: translateX(0%) translateY(0%);
-  }
-}
-@-webkit-keyframes bounce {
-  0% {
-    -webkit-transform: translateY(-100%);
-  }
-
-  60% {
-    -webkit-transform: translateY(5%);
-  }
-
-  85% {
-    -webkit-transform: translateY(0%);
-  }
-}
-@-moz-keyframes bounce {
-  0% {
-    -moz-transform: translateY(-100%);
-  }
-
-  60% {
-    -moz-transform: translateY(5%);
-  }
-
-  85% {
-    -moz-transform: translateY(0%);
-  }
-}
-@-o-keyframes bounce {
-  0% {
-    -o-transform: translateY(-100%);
-  }
-
-  60% {
-    -o-transform: translateY(5%);
-  }
-
-  85% {
-    -o-transform: translateY(0%);
-  }
-}
-@-ms-keyframes bounce {
-  0% {
-    -ms-transform: translateY(-100%);
-  }
-
-  60% {
-    -ms-transform: translateY(5%);
-  }
-
-  85% {
-    -ms-transform: translateY(0%);
-  }
-}
-@keyframes bounce {
-  0% {
-    transform: translateY(-100%);
-  }
-
-  60% {
-    transform: translateY(5%);
-  }
-
-  85% {
-    transform: translateY(0%);
-  }
-}
-.modal--bouncefromtop .modal-close:before {
-  -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
-  transition: all 0.4s;
-  opacity: 0;
-}
-.modal--bouncefromtop .modal-close:after {
-  -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
-  transition: all 0.4s;
-  -webkit-transition-delay: 0.4s;
-  -o-transition-delay: 0.4s;
-  transition-delay: 0.4s;
-  opacity: 0;
-  top: 25px;
-}
-.modal--bouncefromtop:target .modal-inner, .is-active.modal--bouncefromtop .modal-inner {
-  -webkit-animation-name: bounce;
-  -moz-animation-name: bounce;
-  -o-animation-name: bounce;
-  -ms-animation-name: bounce;
-  animation-name: bounce;
-  -webkit-animation-duration: 0.4s;
-  -moz-animation-duration: 0.4s;
-  -o-animation-duration: 0.4s;
-  -ms-animation-duration: 0.4s;
-  animation-duration: 0.4s;
-  -webkit-animation-fill-mode: both;
-  -moz-animation-fill-mode: both;
-  -o-animation-fill-mode: both;
-  -ms-animation-fill-mode: both;
-  animation-fill-mode: both;
-  opacity: 1;
-}
-.modal--bouncefromtop:target .modal-close:before, .is-active.modal--bouncefromtop .modal-close:before {
-  opacity: 1;
-}
-.modal--bouncefromtop:target .modal-close:after, .is-active.modal--bouncefromtop .modal-close:after {
-  opacity: 1;
-  top: 25px;
-}
-@media screen and (max-width: 30em) {
-  .modal--bouncefromtop:target .modal-close:after, .is-active.modal--bouncefromtop .modal-close:after {
-    top: 5px;
-    right: 5px;
-    left: auto;
-  }
-}
-
-.modal--bouncefromtopshaky .modal-close:before {
-  -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
-  transition: all 0.4s;
-  opacity: 0;
-}
-.modal--bouncefromtopshaky .modal-close:after {
-  -webkit-transition: all 0.4s;
-  -o-transition: all 0.4s;
-  transition: all 0.4s;
-  -webkit-transition-delay: 0.6s;
-  -o-transition-delay: 0.6s;
-  transition-delay: 0.6s;
-  opacity: 0;
-  top: 25px;
-}
-.modal--bouncefromtopshaky:target .modal-inner, .is-active.modal--bouncefromtopshaky .modal-inner {
-  -webkit-animation-name: shaky;
-  -moz-animation-name: shaky;
-  -o-animation-name: shaky;
-  -ms-animation-name: shaky;
-  animation-name: shaky;
-  -webkit-animation-duration: 0.6s;
-  -moz-animation-duration: 0.6s;
-  -o-animation-duration: 0.6s;
-  -ms-animation-duration: 0.6s;
-  animation-duration: 0.6s;
-  -webkit-animation-fill-mode: both;
-  -moz-animation-fill-mode: both;
-  -o-animation-fill-mode: both;
-  -ms-animation-fill-mode: both;
-  animation-fill-mode: both;
-  opacity: 1;
-}
-.modal--bouncefromtopshaky:target .modal-close:before, .is-active.modal--bouncefromtopshaky .modal-close:before {
-  opacity: 1;
-}
-.modal--bouncefromtopshaky:target .modal-close:after, .is-active.modal--bouncefromtopshaky .modal-close:after {
-  opacity: 1;
-  top: 25px;
-}
-@media screen and (max-width: 30em) {
-  .modal--bouncefromtopshaky:target .modal-close:after, .is-active.modal--bouncefromtopshaky .modal-close:after {
-    top: 5px;
-    right: 5px;
-    left: auto;
-  }
-}
-
 /**
  * CSS Modal Themes
  * http://drublic.github.com/css-modal
@@ -690,45 +365,45 @@ html {
 /*
  * Global Theme Styles
  */
-.modal--gallery, .modal--fade, .modal--plainscreen, .modal--zoomin, .modal--zoomout, .modal--slidefromtop, .modal--bouncefromtop, .modal--bouncefromtopshaky, .modal--show {
-  color: #222222;
+.modal--gallery, .modal--fade, .modal--plainscreen, .modal--zoomin, .modal--show {
+  color: #222;
   line-height: 1.3;
 }
-.modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--zoomout .modal-inner, .modal--slidefromtop .modal-inner, .modal--bouncefromtop .modal-inner, .modal--bouncefromtopshaky .modal-inner, .modal--show .modal-inner {
+.modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--show .modal-inner {
   border-radius: 2px;
-  background: white;
+  background: #fff;
   -webkit-box-shadow: 0 0 30px rgba(0, 0, 0, 0.6);
   box-shadow: 0 0 30px rgba(0, 0, 0, 0.6);
   max-width: 100%;
   -webkit-transition: max-width 0.25s linear, margin-left 0.125s linear;
   transition: max-width 0.25s linear, margin-left 0.125s linear;
 }
-.modal--gallery header, .modal--fade header, .modal--plainscreen header, .modal--zoomin header, .modal--zoomout header, .modal--slidefromtop header, .modal--bouncefromtop header, .modal--bouncefromtopshaky header, .modal--show header {
-  border-bottom: 1px solid #dddddd;
+.modal--gallery header, .modal--fade header, .modal--plainscreen header, .modal--zoomin header, .modal--show header {
+  border-bottom: 1px solid #ddd;
   padding: 0 1.2em;
 }
-.modal--gallery header > h2, .modal--fade header > h2, .modal--plainscreen header > h2, .modal--zoomin header > h2, .modal--zoomout header > h2, .modal--slidefromtop header > h2, .modal--bouncefromtop header > h2, .modal--bouncefromtopshaky header > h2, .modal--show header > h2 {
+.modal--gallery header > h2, .modal--fade header > h2, .modal--plainscreen header > h2, .modal--zoomin header > h2, .modal--show header > h2 {
   margin: 0.5em 0;
 }
-.modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--zoomout .modal-content, .modal--slidefromtop .modal-content, .modal--bouncefromtop .modal-content, .modal--bouncefromtopshaky .modal-content, .modal--show .modal-content {
-  border-bottom: 1px solid #dddddd;
+.modal--gallery .modal-content, .modal--fade .modal-content, .modal--plainscreen .modal-content, .modal--zoomin .modal-content, .modal--show .modal-content {
+  border-bottom: 1px solid #ddd;
   padding: 15px 1.2em;
 }
-.modal--gallery footer, .modal--fade footer, .modal--plainscreen footer, .modal--zoomin footer, .modal--zoomout footer, .modal--slidefromtop footer, .modal--bouncefromtop footer, .modal--bouncefromtopshaky footer, .modal--show footer {
+.modal--gallery footer, .modal--fade footer, .modal--plainscreen footer, .modal--zoomin footer, .modal--show footer {
   border-top: 1px solid white;
   padding: 0 1.2em 18px;
   background: #f0f0f0;
   border-radius: 2px;
 }
-.modal--gallery .modal-close, .modal--fade .modal-close, .modal--plainscreen .modal-close, .modal--zoomin .modal-close, .modal--zoomout .modal-close, .modal--slidefromtop .modal-close, .modal--bouncefromtop .modal-close, .modal--bouncefromtopshaky .modal-close, .modal--show .modal-close {
+.modal--gallery .modal-close, .modal--fade .modal-close, .modal--plainscreen .modal-close, .modal--zoomin .modal-close, .modal--show .modal-close {
   text-indent: -100px;
 }
-.modal--gallery .modal-close:before, .modal--fade .modal-close:before, .modal--plainscreen .modal-close:before, .modal--zoomin .modal-close:before, .modal--zoomout .modal-close:before, .modal--slidefromtop .modal-close:before, .modal--bouncefromtop .modal-close:before, .modal--bouncefromtopshaky .modal-close:before, .modal--show .modal-close:before {
+.modal--gallery .modal-close:before, .modal--fade .modal-close:before, .modal--plainscreen .modal-close:before, .modal--zoomin .modal-close:before, .modal--show .modal-close:before {
   background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAQAAAC1+jfqAAAAEUlEQVQoz2NgeEYAjioYSQoAzOTmAXhPhyoAAAAASUVORK5CYII=");
 }
-.modal--gallery .modal-close:after, .modal--fade .modal-close:after, .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after, .modal--zoomout .modal-close:after, .modal--slidefromtop .modal-close:after, .modal--bouncefromtop .modal-close:after, .modal--bouncefromtopshaky .modal-close:after, .modal--show .modal-close:after {
+.modal--gallery .modal-close:after, .modal--fade .modal-close:after, .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after, .modal--show .modal-close:after {
   content: '\00d7';
-  background: white;
+  background: #fff;
   border-radius: 2px;
   padding: 2px 8px;
   font-size: 1.2em;
@@ -736,7 +411,7 @@ html {
   text-indent: 0;
 }
 @media screen and (max-width: 30em) {
-  .modal--gallery:before, .modal--fade:before, .modal--plainscreen:before, .modal--zoomin:before, .modal--zoomout:before, .modal--slidefromtop:before, .modal--bouncefromtop:before, .modal--bouncefromtopshaky:before, .modal--show:before {
+  .modal--gallery:before, .modal--fade:before, .modal--plainscreen:before, .modal--zoomin:before, .modal--show:before {
     background-color: #27aae2;
     background-image: -webkit-gradient(linear, left top, left bottom, from(#27aae2), to(#1c9cd3));
     background-image: -webkit-linear-gradient(top, #27aae2, #1c9cd3);
@@ -747,15 +422,15 @@ html {
     -webkit-box-shadow: 0 0 5px rgba(0, 0, 0, 0.6);
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.6);
   }
-  .modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--zoomout .modal-inner, .modal--slidefromtop .modal-inner, .modal--bouncefromtop .modal-inner, .modal--bouncefromtopshaky .modal-inner, .modal--show .modal-inner {
+  .modal--gallery .modal-inner, .modal--fade .modal-inner, .modal--plainscreen .modal-inner, .modal--zoomin .modal-inner, .modal--show .modal-inner {
     padding-top: 3em;
     -webkit-box-shadow: none;
     box-shadow: none;
   }
-  .modal--gallery .modal-close, .modal--fade .modal-close, .modal--plainscreen .modal-close, .modal--zoomin .modal-close, .modal--zoomout .modal-close, .modal--slidefromtop .modal-close, .modal--bouncefromtop .modal-close, .modal--bouncefromtopshaky .modal-close, .modal--show .modal-close {
+  .modal--gallery .modal-close, .modal--fade .modal-close, .modal--plainscreen .modal-close, .modal--zoomin .modal-close, .modal--show .modal-close {
     text-decoration: none;
   }
-  .modal--gallery .modal-close:after, .modal--fade .modal-close:after, .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after, .modal--zoomout .modal-close:after, .modal--slidefromtop .modal-close:after, .modal--bouncefromtop .modal-close:after, .modal--bouncefromtopshaky .modal-close:after, .modal--show .modal-close:after {
+  .modal--gallery .modal-close:after, .modal--fade .modal-close:after, .modal--plainscreen .modal-close:after, .modal--zoomin .modal-close:after, .modal--show .modal-close:after {
     content: attr(data-close);
     font-size: 1em;
     padding: 0.5em 1em;
@@ -770,13 +445,16 @@ html {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
 }
 .modal--plainscreen .modal-close:before {
-  background: white;
+  background: #fff;
 }
 .modal--plainscreen .modal-close:after {
   -webkit-box-shadow: 0px -4px 8px -1px rgba(0, 0, 0, 0.25);
   box-shadow: 0px -4px 8px -1px rgba(0, 0, 0, 0.25);
 }
 
+/**
+ * Apply the desired modal behavior to your container selector
+ */
 /**
  * CSS Modal Theme 'Resize'
  * http://drublic.github.com/css-modal
@@ -956,7 +634,7 @@ html {
  * Caption
  */
 .modal--gallery-caption {
-  border-bottom: 1px solid #dddddd;
+  border-bottom: 1px solid #ddd;
 }
 .modal--gallery-caption p {
   margin: 1em 15px;
@@ -972,7 +650,6 @@ html {
     -ms-transform: rotate(0deg);
     transform: rotate(0deg);
   }
-
   100% {
     -webkit-transform: rotate(1080deg);
     -ms-transform: rotate(1080deg);
@@ -983,7 +660,6 @@ html {
   0% {
     -webkit-transform: rotate(0deg);
   }
-
   100% {
     -webkit-transform: rotate(1080deg);
   }
@@ -994,7 +670,6 @@ html {
     -ms-transform: rotate(720deg);
     transform: rotate(720deg);
   }
-
   100% {
     -webkit-transform: rotate(0deg);
     -ms-transform: rotate(0deg);
@@ -1005,7 +680,6 @@ html {
   0% {
     -webkit-transform: rotate(720deg);
   }
-
   100% {
     -webkit-transform: rotate(0deg);
   }
@@ -1031,7 +705,7 @@ html {
   content: '';
   margin: 5%;
   border-radius: 100%;
-  background: white;
+  background: #fff;
 }
 .spinner .spinner__outer,
 .spinner .spinner__inner {
@@ -1113,3 +787,5 @@ html {
     margin-top: 0;
   }
 }
+
+/*# sourceMappingURL=modal.css.map */

--- a/test/modal.scss
+++ b/test/modal.scss
@@ -30,22 +30,6 @@
 	@extend %modal--transition-plainScreen;
 }
 
-.modal--zoomout {
-	@extend %modal--transition-zoomOut;
-}
-
-.modal--slidefromtop {
-	@extend %modal--transition-slideFromTop;
-}
-
-.modal--bouncefromtop {
-	@extend %modal--transition-bounceFromTop;
-}
-
-.modal--bouncefromtopshaky {
-	@extend %modal--transition-bounceFromTopShaky;
-}
-
 [data-cssmodal-resize] {
 	@extend %modal--resize;
 }


### PR DESCRIPTION
This fixes #161 and updates the syntax of the remaining animations of the modal. In favor of maintainability I’ve dropped the old funky animations and will not provide them as plugin. They’re just not for real use.
