### PR TITLE
Add possibiliry to make modals non-stackable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## HEAD
+* Add possibiliry to make modals non-stackable
 
 ## 1.2.0 - 19.11.2014
 * Fix IE8 error with HTML5 video plugin

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ fast!
 
 ## How to use
 
+Please be aware that modals get stacked above each other if you open one modal
+from within another. You can add a data-attribute `data-stackable="false"` to
+the modal in order to make it non-stackable.
+
 ### Markup
 
 You need to include the markup and content for modals in your website. This has

--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
 				<div class="modal-content">
 					<p>Content.</p>
 					<p><a href="#stackable">Stackable Modal</a></p>
+					<p><a href="#modal-fade">Non-Stackable Modal</a></p>
 
 					<p>Fap raw denim Marfa, eu lomo artisan jean shorts. Next level YOLO biodiesel PBR. Irure farm-to-table cardigan, culpa helvetica nostrud nulla messenger bag. Leggings gentrify iPhone dreamcatcher dolor. Butcher PBR est scenester McSweeney's, retro et single-origin coffee vegan irony. <a href="#">http://www.thisisalongtestlinkaaaaaaaaaaaaaaaaaaaaaaaaaaaa.com/here-is-our-article-text-url-which-is-very-long</a>. Dolore twee wayfarers beard yr mlkshk biodiesel, art party sint gastropub eiusmod fixie. Banksy sed DIY put a bird on it gentrify raw denim, art party vero keffiyeh cred aesthetic.</p>
 
@@ -92,7 +93,7 @@
 					data-dismiss="modal" data-close="Close">&times;</a>
 		</section>
 
-		<section class="modal--fade" id="modal-fade"
+		<section class="modal--fade" id="modal-fade" data-stackable="false"
 				tabindex="-1" role="dialog" aria-labelledby="label-fade" aria-hidden="true">
 
 			<div class="modal-inner">

--- a/modal.js
+++ b/modal.js
@@ -278,9 +278,10 @@
 
 		/*
 		 * Unset previous active modal
-		 * @param isStacked {boolean} true if element is stacked above another
+		 * @param isStacked          {boolean} `true` if element is stacked above another
+		 * @param shouldNotBeStacked {boolean} `true` if next element should be stacked
 		 */
-		unsetActive: function (isStacked) {
+		unsetActive: function (isStacked, shouldNotBeStacked) {
 			if (modal.activeElement) {
 				modal.removeClass(modal.activeElement, 'is-active');
 
@@ -294,7 +295,7 @@
 				modal.removeFocus();
 
 				// Make modal stacked if needed
-				if (isStacked) {
+				if (isStacked && !shouldNotBeStacked) {
 					modal.stackModal(modal.activeElement);
 				}
 
@@ -385,7 +386,10 @@
 					modal.addClass(document.documentElement, 'has-overlay');
 
 					// Make previous element stackable if it is not the same modal
-					modal.unsetActive( !modal.hasClass(modalElement, 'is-active') );
+					modal.unsetActive(
+						!modal.hasClass(modalElement, 'is-active'),
+						(modalElement.getAttribute('data-stackable') === 'false')
+					);
 
 					// Mark the active element
 					modal.setActive(modalElement);

--- a/test/index.html
+++ b/test/index.html
@@ -54,6 +54,20 @@
 					data-dismiss="modal" data-close="Close">&times;</a>
 		</section>
 
+		<!-- A modal with its content -->
+		<section class="_modal" id="non-stackable"
+				style="top: 101%;"
+				tabindex="-1" role="dialog" aria-labelledby="modal-label" aria-hidden="true">
+
+			<div class="modal-inner">
+				<div class="modal-content"></div>
+			</div>
+
+			<!-- Use Hash-Bang to maintain scroll position when closing modal -->
+			<a href="#!" class="modal-close" title="Close this modal"
+					data-dismiss="modal" data-close="Close">&times;</a>
+		</section>
+
 		<!-- Source -->
 		<script src="../modal.js"></script>
 

--- a/test/spec/modal.js
+++ b/test/spec/modal.js
@@ -225,6 +225,13 @@
 				}, 0);
 			});
 
+			it('does not stack when defined', function () {
+				window.location.hash = '#modal';
+				window.location.hash = '#non-stackable';
+
+				expect($modal.hasClass('is-stacked')).not.toBe(true);
+			});
+
 
 		});
 	});


### PR DESCRIPTION
It is possible to not stack modals when opening them from another modal
now by applying a data attribute: `data-stackable="false"`.

This option is `true` by default.

Reference #146.
