### PR TITLE
Gallery: Add possibility to use iframes in slides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## HEAD
+* Gallery: Add possibility to use iframes in slides
 * Add possibility to make modals non-stackable
 * Remove unused lt IE8 hack for scrollbars: fixes respond.js issues
 

--- a/index.html
+++ b/index.html
@@ -282,6 +282,13 @@
 										data-src-fullsize="test/img/cat.jpg">
 							</a>
 						</li>
+						<li data-caption="Escape is not his plan.">
+							<a href="#modal-gallery/8" data-iframe>
+								<img alt="Escape is not his plan."
+										src="test/img/cat-small.jpg"
+										data-src-fullsize="//player.vimeo.com/video/113287920">
+							</a>
+						</li>
 					</ul>
 				</footer>
 			</div>

--- a/plugins/gallery.js
+++ b/plugins/gallery.js
@@ -219,8 +219,19 @@
 		// Load the original image, if we are in a gallery
 		if (_activeElement.getAttribute('class').indexOf('modal--gallery') !== -1) {
 			referenceImage = _detailView.getElementsByTagName('img')[0];
-			img.src = referenceImage.getAttribute('data-src-fullsize');
-			img.alt = referenceImage.getAttribute('alt');
+
+			if (referenceImage.parentNode.getAttribute('data-iframe') !== null) {
+				img = document.createElement('iframe');
+
+				img.src = referenceImage.getAttribute('data-src-fullsize');
+				img.setAttribute('webkitallowfullscreen', true);
+				img.setAttribute('mozallowfullscreen', true);
+				img.setAttribute('allowfullscreen', true);
+
+			} else {
+				img.src = referenceImage.getAttribute('data-src-fullsize');
+				img.alt = referenceImage.getAttribute('alt');
+			}
 
 			// Reposition and show
 			CSSModal.on('load', img, function () {

--- a/plugins/gallery.scss
+++ b/plugins/gallery.scss
@@ -2,8 +2,10 @@
  * CSS Modal Plugin for displaying an image gallery
  *
  * @author Jonathan Weiß
+ * @author Hans Christian Reinl
  * @date 2014-05-16
  */
+$gallery--iframe-size: 600px !default;
 $gallery--min-size: 98px;
 $gallery--thumb-size: 98px;
 
@@ -53,6 +55,44 @@ $gallery--thumb-size: 98px;
 		height: auto;
 		-webkit-transition: opacity 0.2s ease-out;
 		        transition: opacity 0.2s ease-out;
+	}
+
+	/**
+	 * Styling for Iframe in modal
+	 */
+	> [data-iframe] {
+		position: relative;
+		float: left;
+		width: $gallery--iframe-size;
+
+		&:after {
+			float: left;
+			content: '';
+			padding-top: 56.25%;
+		}
+	}
+
+	iframe {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		width: 100%;
+		height: 100%;
+		border: 0;
+	}
+
+	@media screen and (max-width: $modal-max-width + 40) {
+		> [data-iframe] {
+			width: 411px;
+		}
+	}
+
+	@media screen and (max-width: $modal-small-breakpoint) {
+		> [data-iframe] {
+			width: 100%;
+		}
 	}
 }
 


### PR DESCRIPTION
A gallery can now handle iframes: Just provide a link to the according
iframe in `data-src-fullsize` instead of an image and set `data-iframe`
on the enclosing link.

```
<a href="#modal-gallery/iframe" data-iframe>
    <img alt="" src="image.jpg" data-src-fullsize="//iframe-url.com/">
</a>
```

This adds functionality for videos from Vimeo and Youtube. They are not
paused when skipping to the next/prev element. Please consider adding a
custom script for handling this behavior.

The defined max-width of an iframe is currently 600px. You can change
this by setting a variable `$gallery--iframe-size` which overwrites the
current default value.

Please have a look, @melros.
