### PR TITLE
Allow links to surround other html elements

### DIFF
--- a/modal.js
+++ b/modal.js
@@ -358,7 +358,7 @@
 
 			// JS-only: no hash present
 			if (noHash) {
-				hash = event.target.getAttribute('href').replace('#', '');
+				hash = event.currentTarget.getAttribute('href').replace('#', '');
 			}
 
 			modalElement = document.getElementById(hash);


### PR DESCRIPTION
The current javascript breaks if the `<a>` surrounds an `<img>` or other html.