### PR TITLE
Missing commas

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   ],
   "author": "Hans Christian Reinl",
   "ignore": [
-    ".misc"
+    ".misc",
     "Gruntfile.js",
     "node_modules",
     "package.json",

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "Gruntfile.js",
     "node_modules",
     "package.json",
-    "test/modal.css"
+    "test/modal.css",
     ".gitignore",
     ".travis.yml",
     "CONTRIBUTE.md"


### PR DESCRIPTION
There are missing commas in the bower.json file, preventing it from being installed properly. 