### PR TITLE
Changed to https

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
 						<h2 id="modal-label-2">Embed videos</h2>
 					</header>
 
-					<iframe src="http://www.youtube.com/embed/DO48AqJ2CEw?rel=0"
+					<iframe src="https://www.youtube.com/embed/DO48AqJ2CEw?rel=0"
 							frameborder="0" allowfullscreen></iframe>
 
 					<footer>


### PR DESCRIPTION
Mozilla blocks this connection as it is considered mixed content, as the page is https while the iframe is http. https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content?utm_source=mozilla&utm_medium=firefox-console-errors&utm_campaign=default