### PR TITLE
docs: Fix simple typo, listerns -> listeners

### DIFF
--- a/js/CSSModalGallery.js
+++ b/js/CSSModalGallery.js
@@ -95,7 +95,7 @@ class CSSModalGallery extends CSSModal {
   }
 
   /**
-   * Registers the listerns on the previous / next buttons to enable gallery
+   * Registers the listeners on the previous / next buttons to enable gallery
    * navigation
    * @return {void}
    */


### PR DESCRIPTION
There is a small typo in js/CSSModalGallery.js.

Should read `listeners` rather than `listerns`.

